### PR TITLE
Added No Use Case Handler

### DIFF
--- a/payment-api/domain/src/main/java/com/hexagonaldemo/paymentapi/common/usecase/BeanAwareUseCasePublisher.java
+++ b/payment-api/domain/src/main/java/com/hexagonaldemo/paymentapi/common/usecase/BeanAwareUseCasePublisher.java
@@ -33,6 +33,14 @@ public class BeanAwareUseCasePublisher implements UseCasePublisher {
         }
     }
 
+    @Override
+    @SuppressWarnings("unchecked")
+    public <R> R publish(Class<R> returnClass) {
+        var useCaseHandler = (NoUseCaseHandler<R>) UseCaseHandlerRegistry.INSTANCE.detectNoUseCaseHandlerFrom(returnClass);
+        validateNoParamUseCaseHandlerDetection(useCaseHandler);
+        return useCaseHandler.handle();
+    }
+
     private <R, T extends UseCase> void validateUseCaseHandlerDetection(T useCase, UseCaseHandler<R, T> useCaseHandler) {
         if (Objects.isNull(useCaseHandler)) {
             log.error("Use case handler cannot be detected for the use case: {}, handlers: {}", useCase, UseCaseHandlerRegistry.INSTANCE.getRegistryForUseCaseHandlers());
@@ -47,4 +55,10 @@ public class BeanAwareUseCasePublisher implements UseCasePublisher {
         }
     }
 
+    private <R> void validateNoParamUseCaseHandlerDetection(NoUseCaseHandler<R> useCaseHandler) {
+        if (Objects.isNull(useCaseHandler)) {
+            log.error("Void use case handler cannot be detected for the handlers: {}", UseCaseHandlerRegistry.INSTANCE.getRegistryForNoUseCaseHandlers());
+            throw new PaymentApiBusinessException("paymentapi.useCaseHandler.notDetected");
+        }
+    }
 }

--- a/payment-api/domain/src/main/java/com/hexagonaldemo/paymentapi/common/usecase/NoUseCaseHandler.java
+++ b/payment-api/domain/src/main/java/com/hexagonaldemo/paymentapi/common/usecase/NoUseCaseHandler.java
@@ -1,0 +1,6 @@
+package com.hexagonaldemo.paymentapi.common.usecase;
+
+public interface NoUseCaseHandler<R> {
+
+    R handle();
+}

--- a/payment-api/domain/src/main/java/com/hexagonaldemo/paymentapi/common/usecase/ObservableUseCasePublisher.java
+++ b/payment-api/domain/src/main/java/com/hexagonaldemo/paymentapi/common/usecase/ObservableUseCasePublisher.java
@@ -11,4 +11,8 @@ public class ObservableUseCasePublisher extends BeanAwareUseCasePublisher {
     public <T extends UseCase> void register(Class<T> useCaseClass, VoidUseCaseHandler<T> useCaseHandler) {
         UseCaseHandlerRegistry.INSTANCE.register(useCaseClass, useCaseHandler);
     }
+
+    public <R> void register(Class<R> returnClass, NoUseCaseHandler<R> useCaseHandler) {
+        UseCaseHandlerRegistry.INSTANCE.register(returnClass, useCaseHandler);
+    }
 }

--- a/payment-api/domain/src/main/java/com/hexagonaldemo/paymentapi/common/usecase/UseCaseHandlerRegistry.java
+++ b/payment-api/domain/src/main/java/com/hexagonaldemo/paymentapi/common/usecase/UseCaseHandlerRegistry.java
@@ -13,12 +13,14 @@ public class UseCaseHandlerRegistry {
 
     private Map<Class<? extends UseCase>, UseCaseHandler<?, ? extends UseCase>> registryForUseCaseHandlers;
     private Map<Class<? extends UseCase>, VoidUseCaseHandler<? extends UseCase>> registryForVoidUseCaseHandlers;
+    private Map<Class<?>, NoUseCaseHandler<?>> registryForNoUseCaseHandlers;
 
     public static final UseCaseHandlerRegistry INSTANCE = new UseCaseHandlerRegistry();
 
     private UseCaseHandlerRegistry() {
         registryForUseCaseHandlers = new HashMap<>();
         registryForVoidUseCaseHandlers = new HashMap<>();
+        registryForNoUseCaseHandlers = new HashMap<>();
     }
 
     public <R, T extends UseCase> void register(Class<T> key, UseCaseHandler<R, T> useCaseHandler) {
@@ -31,11 +33,20 @@ public class UseCaseHandlerRegistry {
         registryForVoidUseCaseHandlers.put(key, useCaseHandler);
     }
 
+    public <R> void register(Class<R> key, NoUseCaseHandler<R> useCaseHandler) {
+        log.info("Use case {} is registered by no param handler {}", key.getSimpleName(), useCaseHandler.getClass().getSimpleName());
+        registryForNoUseCaseHandlers.put(key, useCaseHandler);
+    }
+
     public UseCaseHandler<?, ? extends UseCase> detectUseCaseHandlerFrom(Class<? extends UseCase> useCaseClass) {
         return registryForUseCaseHandlers.get(useCaseClass);
     }
 
     public VoidUseCaseHandler<? extends UseCase> detectVoidUseCaseHandlerFrom(Class<? extends UseCase> useCaseClass) {
         return registryForVoidUseCaseHandlers.get(useCaseClass);
+    }
+
+    public NoUseCaseHandler<?> detectNoUseCaseHandlerFrom(Class<?> returnClass) {
+        return registryForNoUseCaseHandlers.get(returnClass);
     }
 }

--- a/payment-api/domain/src/main/java/com/hexagonaldemo/paymentapi/common/usecase/UseCasePublisher.java
+++ b/payment-api/domain/src/main/java/com/hexagonaldemo/paymentapi/common/usecase/UseCasePublisher.java
@@ -7,4 +7,6 @@ public interface UseCasePublisher {
     <R, T extends UseCase> R publish(Class<R> returnClass, T useCase);
 
     <R, T extends UseCase> void publish(T useCase);
+
+    <R> R publish(Class<R> returnClass);
 }


### PR DESCRIPTION
it's been added the no param use case handler to be able to handle without any use case and return a response model

By the way, Thanks a lot for this great boilerplate project which you have been released with @lemiorhan. We also have got a production-ready project that this project's help us, it will be released in the near future 🙂

We needed to return static content to our mobile clients without depending on any request model, that's why we added up the **NoUseCaseHandler**