### PR TITLE
Added paradigm for UseCase input validation.

### DIFF
--- a/payment-api/domain/src/main/java/com/hexagonaldemo/paymentapi/common/model/UseCase.java
+++ b/payment-api/domain/src/main/java/com/hexagonaldemo/paymentapi/common/model/UseCase.java
@@ -1,4 +1,6 @@
 package com.hexagonaldemo.paymentapi.common.model;
 
 public interface UseCase {
+
+    default void isSatisfied() {}
 }

--- a/payment-api/domain/src/main/java/com/hexagonaldemo/paymentapi/common/usecase/BeanAwareUseCasePublisher.java
+++ b/payment-api/domain/src/main/java/com/hexagonaldemo/paymentapi/common/usecase/BeanAwareUseCasePublisher.java
@@ -16,6 +16,7 @@ public class BeanAwareUseCasePublisher implements UseCasePublisher {
     public <R, T extends UseCase> R publish(Class<R> returnClass, T useCase) {
         var useCaseHandler = (UseCaseHandler<R, T>) UseCaseHandlerRegistry.INSTANCE.detectUseCaseHandlerFrom(useCase.getClass());
         validateUseCaseHandlerDetection(useCase, useCaseHandler);
+        useCase.isSatisfied();
         return useCaseHandler.handle(useCase);
     }
 
@@ -26,9 +27,11 @@ public class BeanAwareUseCasePublisher implements UseCasePublisher {
         if (Objects.isNull(voidUseCaseHandler)) {
             var useCaseHandler = (UseCaseHandler<R, T>) UseCaseHandlerRegistry.INSTANCE.detectUseCaseHandlerFrom(useCase.getClass());
             validateUseCaseHandlerDetection(useCase, useCaseHandler);
+            useCase.isSatisfied();
             useCaseHandler.handle(useCase);
         } else {
             validateVoidUseCaseHandlerDetection(useCase, voidUseCaseHandler);
+            useCase.isSatisfied();
             voidUseCaseHandler.handle(useCase);
         }
     }


### PR DESCRIPTION
Hello,

I hope this message finds you well and enjoying your weekend. I am a backend developer from South Korea who has been studying Hexagonal Architecture and gaining various insights through your Modular-Architecture-Hexagonal-Demo-Project.

While studying your source code, I pondered on the part about input validation. Since the UseCaseHandler is called through the publisher, it seems we have to do input validation twice: once at the REST level, and then again at the UseCaseHandler level.

I found this situation to be quite inefficient. Consequently, I thought of creating an isSatisfied method in the UseCase interface, which is invoked within the Publisher method prior to calling the handle method of UseCaseHandler. This approach seems to streamline the process of validating input values, avoiding unnecessary repetitions.

With this approach, the following benefits were observed:

We can directly bind from the API to the UseCase.
We can achieve unified domain UseCase input validation.
We can focus the business logic in UseCaseHandler.
I have applied these thoughts in code and am submitting them in this Pull Request. As I am not very experienced, I may not have considered all perspectives. Even if this does not contribute directly, I would very much appreciate your candid feedback.